### PR TITLE
Apply latest CheriBSD fixes to jemalloc copy

### DIFF
--- a/jemalloc/include/jemalloc/internal/extent_inlines.h
+++ b/jemalloc/include/jemalloc/internal/extent_inlines.h
@@ -217,7 +217,7 @@ extent_addr_randomize(UNUSED tsdn_t *tsdn, extent_t *extent, size_t alignment) {
 			    &extent_arena_get(extent)->offset_state,
 			    lg_range, true);
 		}
-		uintptr_t random_offset = r << (LG_PAGE - lg_range);
+		size_t random_offset = r << (LG_PAGE - lg_range);
 		extent->e_addr = (void *)((uintptr_t)extent->e_addr +
 		    random_offset);
 		assert(ALIGNMENT_ADDR2BASE(extent->e_addr, alignment) ==
@@ -314,7 +314,9 @@ extent_init(extent_t *extent, arena_t *arena, void *addr, size_t size,
     bool slab, szind_t szind, size_t sn, extent_state_t state, bool zeroed,
     bool committed, bool dumpable) {
 	assert(addr == PAGE_ADDR2BASE(addr) || !slab);
-
+#ifdef __CHERI_PURE_CAPABILITY__
+	assert(cheri_getoffset(extent) == 0 && "extent offset must be zero for packing in rtree");
+#endif
 	extent_arena_set(extent, arena);
 	extent_addr_set(extent, addr);
 	extent_size_set(extent, size);

--- a/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -35,8 +35,7 @@ unbound_ptr(tsdn_t *tsdn, void *ptr) {
 	extent = rtree_extent_read(tsdn, &extents_rtree,
 	    rtree_ctx, (vaddr_t)ptr, true);
 	assert(extent != NULL);
-	ubptr = cheri_incoffset(extent->e_addr,
-	    (vaddr_t)ptr - (vaddr_t)extent->e_addr);
+	ubptr = cheri_setaddress(extent->e_addr, (vaddr_t)ptr);
 	assert((vaddr_t)ptr == (vaddr_t)ubptr);
 	assert(cheri_getbase(ubptr) == cheri_getbase(extent->e_addr));
 	assert(cheri_getlen(ubptr) == cheri_getlen(extent->e_addr));

--- a/jemalloc/include/jemalloc/jemalloc_FreeBSD.h
+++ b/jemalloc/include/jemalloc/jemalloc_FreeBSD.h
@@ -16,11 +16,13 @@
 
 #undef JEMALLOC_OVERRIDE_VALLOC
 
-#ifndef MALLOC_PRODUCTION
+#if !defined(MALLOC_PRODUCTION) && !defined(MALLOC_DEBUG)
 #define	MALLOC_PRODUCTION
 #endif
+
 #ifndef MALLOC_PRODUCTION
 #define	JEMALLOC_DEBUG
+#pragma message("JEMALLOC_DEBUG enabled!")
 #endif
 
 #undef JEMALLOC_DSS
@@ -73,7 +75,7 @@
 #endif
 #ifdef __mips__
 #ifdef __mips_n64
-#  define LG_VADDR		64
+#  define LG_VADDR		48
 #  define LG_SIZEOF_PTR		3
 #else
 #  define LG_VADDR		32

--- a/jemalloc/src/arena.c
+++ b/jemalloc/src/arena.c
@@ -385,6 +385,9 @@ arena_extent_alloc_large(tsdn_t *tsdn, arena_t *arena, size_t usize,
 		arena_nactive_add(arena, size >> LG_PAGE);
 	}
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	assert(cheri_getoffset(extent) == 0 && "extent offset must be zero for packing in rtree");
+#endif
 	return extent;
 }
 

--- a/jemalloc/src/base.c
+++ b/jemalloc/src/base.c
@@ -486,6 +486,10 @@ base_alloc_extent(tsdn_t *tsdn, base_t *base) {
 		return NULL;
 	}
 	extent_esn_set(extent, esn);
+#ifdef __CHERI_PURE_CAPABILITY__
+	/* Ensure we return an extent with offset zero for rtree packing */
+	extent = cheri_csetboundsexact(extent, sizeof(*extent));
+#endif
 	return extent;
 }
 

--- a/jemalloc/src/ctl.c
+++ b/jemalloc/src/ctl.c
@@ -1099,7 +1099,7 @@ ctl_lookup(tsdn_t *tsdn, const char *name, ctl_node_t const **nodesp,
 	elm = name;
 	/* Equivalent to strchrnul(). */
 	dot = ((tdot = strchr(elm, '.')) != NULL) ? tdot : strchr(elm, '\0');
-	elen = (size_t)((uintptr_t)dot - (uintptr_t)elm);
+	elen = (size_t)((const char*)dot - (const char*)elm);
 	if (elen == 0) {
 		ret = ENOENT;
 		goto label_return;
@@ -1178,7 +1178,7 @@ ctl_lookup(tsdn_t *tsdn, const char *name, ctl_node_t const **nodesp,
 		elm = &dot[1];
 		dot = ((tdot = strchr(elm, '.')) != NULL) ? tdot :
 		    strchr(elm, '\0');
-		elen = (size_t)((uintptr_t)dot - (uintptr_t)elm);
+		elen = (size_t)((const char*)dot - (const char*)elm);
 	}
 
 	ret = 0;

--- a/jemalloc/src/extent_dss.c
+++ b/jemalloc/src/extent_dss.c
@@ -150,8 +150,8 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 			    (uintptr_t)max_cur));
 			void *ret = (void *)ALIGNMENT_CEILING(
 			    (uintptr_t)gap_addr_page, alignment);
-			size_t gap_size_page = (uintptr_t)ret -
-			    (uintptr_t)gap_addr_page;
+			size_t gap_size_page = (const char*)ret -
+			    (const char*)gap_addr_page;
 			if (gap_size_page != 0) {
 				extent_init(gap, arena, gap_addr_page,
 				    gap_size_page, false, NSIZES,
@@ -169,8 +169,8 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 			}
 			/* Compute the increment, including subpage bytes. */
 			void *gap_addr_subpage = max_cur;
-			size_t gap_size_subpage = (uintptr_t)ret -
-			    (uintptr_t)gap_addr_subpage;
+			size_t gap_size_subpage = (const char*)ret -
+			    (const char*)gap_addr_subpage;
 			intptr_t incr = gap_size_subpage + size;
 
 			assert((uintptr_t)max_cur + incr == (uintptr_t)ret +

--- a/jemalloc/src/jemalloc.c
+++ b/jemalloc/src/jemalloc.c
@@ -30,6 +30,11 @@
 #include "jemalloc/internal/ticker.h"
 #include "jemalloc/internal/util.h"
 
+
+/* Check that we are using je_assert instead of assert(): */
+_Static_assert(__CONCAT(_assert_macro_expansion_is_, assert) == 1,
+    "Should be using je_assert and not assert() from assert.h");
+
 /******************************************************************************/
 /* Data. */
 
@@ -213,8 +218,7 @@ typedef struct {
  * handling is probalby needed in each individual function, returning
  * an appropriate error value.
  */
-#define	ROUND_SIZE(size)						\
-    roundup2((size), (1ULL << CHERI_ALIGN_SHIFT(size)))
+#define	ROUND_SIZE(size)	CHERI_REPRESENTABLE_LENGTH(size)
 #endif
 
 /* Whether encountered any invalid config options. */
@@ -798,6 +802,11 @@ init_opt_stats_print_opts(const char *v, size_t vlen) {
 	assert(opts_len == strlen(opt_stats_print_opts));
 }
 
+static inline ptrdiff_t
+pointer_distance(const void* end, const void* start) {
+	return (const uint8_t*)end - (const uint8_t*)start;
+}
+
 static bool
 malloc_conf_next(char const **opts_p, char const **k_p, size_t *klen_p,
     char const **v_p, size_t *vlen_p) {
@@ -825,7 +834,7 @@ malloc_conf_next(char const **opts_p, char const **k_p, size_t *klen_p,
 			break;
 		case ':':
 			opts++;
-			*klen_p = (uintptr_t)opts - 1 - (uintptr_t)*k_p;
+			*klen_p = pointer_distance(opts, *k_p) - 1;
 			*v_p = opts;
 			accept = true;
 			break;
@@ -856,11 +865,11 @@ malloc_conf_next(char const **opts_p, char const **k_p, size_t *klen_p,
 				malloc_write("<jemalloc>: Conf string ends "
 				    "with comma\n");
 			}
-			*vlen_p = (uintptr_t)opts - 1 - (uintptr_t)*v_p;
+			*vlen_p = pointer_distance(opts, *v_p) - 1;
 			accept = true;
 			break;
 		case '\0':
-			*vlen_p = (uintptr_t)opts - (uintptr_t)*v_p;
+			*vlen_p = pointer_distance(opts, *v_p);
 			accept = true;
 			break;
 		default:
@@ -1015,8 +1024,8 @@ malloc_conf_init(void) {
 									\
 				set_errno(0);				\
 				um = malloc_strtoumax(v, &end, 0);	\
-				if (get_errno() != 0 || (uintptr_t)end -\
-				    (uintptr_t)v != vlen) {		\
+				if (get_errno() != 0 || 		\
+				    pointer_distance(end, v) != vlen) {	\
 					malloc_conf_error(		\
 					    "Invalid conf value",	\
 					    k, klen, v, vlen);		\
@@ -1060,8 +1069,8 @@ malloc_conf_init(void) {
 									\
 				set_errno(0);				\
 				l = strtol(v, &end, 0);			\
-				if (get_errno() != 0 || (uintptr_t)end -\
-				    (uintptr_t)v != vlen) {		\
+				if (get_errno() != 0 || 		\
+				    pointer_distance(end, v) != vlen) {	\
 					malloc_conf_error(		\
 					    "Invalid conf value",	\
 					    k, klen, v, vlen);		\
@@ -2344,21 +2353,6 @@ je_realloc(void *ptr, size_t size) {
 	LOG("core.realloc.entry", "ptr: %p, size: %zu\n", ptr, size);
 
 	if (unlikely(size == 0)) {
-		if (ptr != NULL) {
-			/* realloc(ptr, 0) is equivalent to free(ptr). */
-			UTRACE(ptr, 0, 0);
-			tcache_t *tcache;
-			tsd_t *tsd = tsd_fetch();
-			if (tsd_reentrancy_level_get(tsd) == 0) {
-				tcache = tcache_get(tsd);
-			} else {
-				tcache = NULL;
-			}
-			ifree(tsd, ptr, tcache, true);
-
-			LOG("core.realloc.exit", "result: %p", NULL);
-			return NULL;
-		}
 		size = 1;
 	}
 	size = ROUND_SIZE(size);

--- a/jemalloc/src/malloc_io.c
+++ b/jemalloc/src/malloc_io.c
@@ -376,7 +376,7 @@ malloc_vsnprintf(char *str, size_t size, const char *format, va_list ap) {
 	}								\
 } while (0)
 #define GET_ARG_NUMERIC(val, len) do {					\
-	switch (len) {							\
+	switch ((unsigned char)len) {					\
 	case '?':							\
 		val = va_arg(ap, int);					\
 		break;							\

--- a/jemalloc/src/pages.c
+++ b/jemalloc/src/pages.c
@@ -213,7 +213,7 @@ pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 	 */
 	{
 #ifdef __CHERI_PURE_CAPABILITY__
-		if (size & CHERI_ALIGN_MASK(size))
+		if (size & ~CHERI_REPRESENTABLE_ALIGNMENT_MASK(size))
 			abort();
 #endif
 

--- a/jemalloc/src/tcache.c
+++ b/jemalloc/src/tcache.c
@@ -497,7 +497,7 @@ tcache_destroy(tsd_t *tsd, tcache_t *tcache, bool tsd_tcache) {
 		/* Release the avail array for the TSD embedded auto tcache. */
 		void *avail_array =
 		    (void *)((uintptr_t)tcache_small_bin_get(tcache, 0)->avail -
-		    (uintptr_t)tcache_bin_info[0].ncached_max * sizeof(void *));
+		    (ptrdiff_t)tcache_bin_info[0].ncached_max * sizeof(void *));
 		idalloctm(tsd_tsdn(tsd), avail_array, NULL, NULL, true, true);
 	} else {
 		/* Release both the tcache struct and avail array. */


### PR DESCRIPTION
This shold enable the inline storage of various data structures and slightly
reduce memory usage. It also fixes various new compiler warnings.